### PR TITLE
Workaround for ORCiD kerfuffle

### DIFF
--- a/R/release.R
+++ b/R/release.R
@@ -756,6 +756,7 @@ generate_zenodo_json <- function(repos, local_path, editors_github,
     dplyr::anti_join(tibble::tibble(email = ignore), by = "email") 
   
   # message about orcid API kerfuffle
+  # see <https://fosstodon.org/@sckottie/110216560448583570>
   message("MANUALLY REPLACE WITH ORCID NAMES\n--------------------\n")
   creators_df %>%
     dplyr::filter(lesson_publication_consent == "orcid") %>%


### PR DESCRIPTION
This will skip the ORCiD integration when the service is down and print a message indicating whose names need to be checked with ORCiD manually with links:

```
MANUALLY REPLACE WITH ORCID NAMES
--------------------

Zhian Namir Kamvar ... <https://orcid.org/0000-0003-1458-7108>
       Toby Hodges ... <https://orcid.org/0000-0003-1766-456X>

---------------------
```

@tobyhodges, this should work for you now. See https://fosstodon.org/@sckottie/110216560448583570 for the particular level of h*ck we are living in. 
